### PR TITLE
Add ProcessorNumber in JSON

### DIFF
--- a/Deserializer/RuntimeEventMetadata.cs
+++ b/Deserializer/RuntimeEventMetadata.cs
@@ -119,6 +119,17 @@
             }
         }
 
+        public ushort ProcessorNumber
+        {
+            get
+            {
+                unsafe
+                {
+                    return this.eventRecord->ProcessorNumber;
+                }
+            }
+        }
+
         // logic from: https://msdn.microsoft.com/en-us/library/windows/desktop/dd392308(v=vs.85).aspx
         public ulong[] GetStacks(out ulong matchId)
         {

--- a/EtwJsonWriter.cs
+++ b/EtwJsonWriter.cs
@@ -39,6 +39,9 @@
             this.writer.WritePropertyName("ThreadId");
             this.writer.WriteValue(runtimeMetadata.ThreadId);
 
+            this.writer.WritePropertyName("ProcessorNumber");
+            this.writer.WriteValue(runtimeMetadata.ProcessorNumber);
+
             var activityId = runtimeMetadata.ActivityId;
             if (activityId != Guid.Empty)
             {


### PR DESCRIPTION
Processor Number can be insightful when we don't want to enable CSWITCH events.